### PR TITLE
add ghcr

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check tag format
+        run: |
+          if [[ ! ${{ github.event.release.tag_name }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Release tag must be in the format v{major}.{minor}.{patch} (e.g., v1.0.0)"
+            exit 1
+          fi
+
+  build-and-push:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.event.release.tag_name }}
+            type=semver,pattern=v{{version}},value=${{ github.event.release.tag_name }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ github.event.release.tag_name }}
+            type=semver,pattern=v{{major}},value=${{ github.event.release.tag_name }}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *env/
 *.ipynb
 *__pycache__/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # building base
-FROM python:3.9-slim as base
+FROM python:3.9-slim AS base
 
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /install
 
@@ -22,5 +22,5 @@ COPY --from=builder /ny_times /ny_times
 
 WORKDIR /streamlit
 
-CMD streamlit run app.py
+CMD ["streamlit", "run", "app.py"]
 


### PR DESCRIPTION
This pull request introduces a new workflow for publishing Docker images and makes minor adjustments to the `Dockerfile`. The most important changes include adding a GitHub Actions workflow for Docker image publication.

### New GitHub Actions Workflow:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R59): Added a new workflow to publish Docker images on release, including steps for validating the tag format, building, and pushing the Docker image to the GitHub Container Registry.
